### PR TITLE
Feature - Remove the usage of mixed to have things working with PHP < 8.0

### DIFF
--- a/src/App/WP/Enpii_Base_WP_Plugin.php
+++ b/src/App/WP/Enpii_Base_WP_Plugin.php
@@ -128,7 +128,7 @@ final class Enpii_Base_WP_Plugin extends WP_Plugin {
 	 * @param WP_Query $query
 	 * @return mixed
 	 */
-	public function skip_wp_main_query( $request, $query ): mixed {
+	public function skip_wp_main_query( $request, $query ) {
 		/** @var WP_Query $query */
 		if( $query->is_main_query() && ! $query->is_admin ) {
 			do_action( 'enpii_base_wp_app_do_wp_main_query', $request, $query );
@@ -157,7 +157,10 @@ final class Enpii_Base_WP_Plugin extends WP_Plugin {
 		$kernel->terminate($request, $response);
 	}
 
-	public function skip_wp_template_include( $template ): mixed {
+	/**
+	 * @return mixed
+	 */
+	public function skip_wp_template_include( $template ) {
 		do_action( 'enpii_base_wp_app_render_wp_template', $template );
 
 		return false;
@@ -168,7 +171,7 @@ final class Enpii_Base_WP_Plugin extends WP_Plugin {
 	 * 	and add an action 'enpii_base_wp_app_skip_use_wp_theme' for further actions
 	 * @return mixed
 	 */
-	public function skip_use_wp_theme(): mixed {
+	public function skip_use_wp_theme() {
 		do_action( 'enpii_base_wp_app_skip_use_wp_theme' );
 
 		return false;

--- a/src/Deps/Carbon/CarbonPeriod.php
+++ b/src/Deps/Carbon/CarbonPeriod.php
@@ -2278,7 +2278,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      * @return CarbonInterface[]
      */
     #[ReturnTypeWillChange]
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Deps/Carbon/Language.php
+++ b/src/Deps/Carbon/Language.php
@@ -335,7 +335,7 @@ class Language implements JsonSerializable
      * @return string
      */
     #[ReturnTypeWillChange]
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->getIsoDescription();
     }

--- a/src/Deps/Carbon/Traits/Serialization.php
+++ b/src/Deps/Carbon/Traits/Serialization.php
@@ -232,7 +232,7 @@ trait Serialization
      * @return array|string
      */
     #[ReturnTypeWillChange]
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         $serializer = $this->localSerializer ?? static::$serializer;
 

--- a/src/Deps/Dotenv/Repository/AbstractRepository.php
+++ b/src/Deps/Dotenv/Repository/AbstractRepository.php
@@ -155,7 +155,7 @@ abstract class AbstractRepository implements RepositoryInterface
      * {@inheritdoc}
      */
     #[ReturnTypeWillChange]
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->get($offset);
     }

--- a/src/Deps/Illuminate/Cache/Repository.php
+++ b/src/Deps/Illuminate/Cache/Repository.php
@@ -585,7 +585,7 @@ class Repository implements ArrayAccess, CacheContract
      * @param  string  $key
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->get($key);
     }

--- a/src/Deps/Illuminate/Config/Repository.php
+++ b/src/Deps/Illuminate/Config/Repository.php
@@ -149,7 +149,7 @@ class Repository implements ArrayAccess, ConfigContract
      * @param  string  $key
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->get($key);
     }

--- a/src/Deps/Illuminate/Container/Container.php
+++ b/src/Deps/Illuminate/Container/Container.php
@@ -1278,7 +1278,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $key
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->make($key);
     }

--- a/src/Deps/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Deps/Illuminate/Database/Eloquent/Factory.php
@@ -241,7 +241,7 @@ class Factory implements ArrayAccess
      * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->make($offset);
     }

--- a/src/Deps/Illuminate/Database/Eloquent/Model.php
+++ b/src/Deps/Illuminate/Database/Eloquent/Model.php
@@ -1200,7 +1200,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->toArray();
     }
@@ -1666,7 +1666,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->getAttribute($offset);
     }

--- a/src/Deps/Illuminate/Http/Client/Request.php
+++ b/src/Deps/Illuminate/Http/Client/Request.php
@@ -271,7 +271,7 @@ class Request implements ArrayAccess
      * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->data()[$offset];
     }

--- a/src/Deps/Illuminate/Http/Client/Response.php
+++ b/src/Deps/Illuminate/Http/Client/Response.php
@@ -227,7 +227,7 @@ class Response implements ArrayAccess
      * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->json()[$offset];
     }

--- a/src/Deps/Illuminate/Http/Request.php
+++ b/src/Deps/Illuminate/Http/Request.php
@@ -648,7 +648,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->__get($offset);
     }

--- a/src/Deps/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Deps/Illuminate/Http/Resources/DelegatesToResource.php
@@ -75,7 +75,7 @@ trait DelegatesToResource
      * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->resource[$offset];
     }

--- a/src/Deps/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Deps/Illuminate/Http/Resources/Json/JsonResource.php
@@ -226,7 +226,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      *
      * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->resolve(Container::getInstance()->make('request'));
     }

--- a/src/Deps/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Deps/Illuminate/Pagination/AbstractPaginator.php
@@ -665,7 +665,7 @@ abstract class AbstractPaginator implements Htmlable
      * @param  mixed  $key
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->items->get($key);
     }

--- a/src/Deps/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Deps/Illuminate/Pagination/LengthAwarePaginator.php
@@ -182,7 +182,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Deps/Illuminate/Pagination/Paginator.php
+++ b/src/Deps/Illuminate/Pagination/Paginator.php
@@ -158,7 +158,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      *
      * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Deps/Illuminate/Support/Collection.php
+++ b/src/Deps/Illuminate/Support/Collection.php
@@ -1358,7 +1358,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  mixed  $key
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->items[$key];
     }

--- a/src/Deps/Illuminate/Support/Fluent.php
+++ b/src/Deps/Illuminate/Support/Fluent.php
@@ -70,7 +70,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->toArray();
     }
@@ -103,7 +103,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->get($offset);
     }

--- a/src/Deps/Illuminate/Support/MessageBag.php
+++ b/src/Deps/Illuminate/Support/MessageBag.php
@@ -389,7 +389,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      *
      * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Deps/Illuminate/Support/Optional.php
+++ b/src/Deps/Illuminate/Support/Optional.php
@@ -78,7 +78,7 @@ class Optional implements ArrayAccess
      * @param  mixed  $key
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return Arr::get($this->value, $key);
     }

--- a/src/Deps/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Deps/Illuminate/Support/Traits/EnumeratesValues.php
@@ -765,7 +765,7 @@ trait EnumeratesValues
      *
      * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return array_map(function ($value) {
             if ($value instanceof JsonSerializable) {

--- a/src/Deps/Illuminate/Testing/TestResponse.php
+++ b/src/Deps/Illuminate/Testing/TestResponse.php
@@ -1277,7 +1277,7 @@ class TestResponse implements ArrayAccess
      * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->responseHasView()
                     ? $this->viewData($offset)

--- a/src/Deps/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Deps/Illuminate/View/ComponentAttributeBag.php
@@ -245,7 +245,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->get($offset);
     }

--- a/src/Deps/Illuminate/View/View.php
+++ b/src/Deps/Illuminate/View/View.php
@@ -317,7 +317,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * @param  string  $key
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->data[$key];
     }

--- a/src/Deps/League/CommonMark/Util/ArrayCollection.php
+++ b/src/Deps/League/CommonMark/Util/ArrayCollection.php
@@ -255,7 +255,7 @@ class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAccess
      * @phpstan-return TValue|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->elements[$offset] ?? null;
     }

--- a/src/Deps/Ramsey/Collection/AbstractArray.php
+++ b/src/Deps/Ramsey/Collection/AbstractArray.php
@@ -87,7 +87,7 @@ abstract class AbstractArray implements ArrayInterface
      * @psalm-suppress InvalidAttribute
      */
     #[\ReturnTypeWillChange] // phpcs:ignore
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->data[$offset] ?? null;
     }

--- a/src/Deps/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Deps/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -123,7 +123,7 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
      * @throws \InvalidArgumentException if key does not exist in $this->args
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->getArgument($key);
     }

--- a/src/Deps/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Deps/Symfony/Component/VarDumper/Cloner/Data.php
@@ -165,7 +165,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         return $this->__get($key);
     }


### PR DESCRIPTION
- Remove the usage of `mixed` to have things working with PHP < 8.0 (https://www.php.net/manual/en/language.types.mixed.php)