### PR TITLE
Feature - Add 'wpdb' driver to handle the select query using wpdb instance of WordPress

### DIFF
--- a/src/App/Http/Controllers/Index_Controller.php
+++ b/src/App/Http/Controllers/Index_Controller.php
@@ -4,12 +4,28 @@ declare(strict_types=1);
 
 namespace Enpii_Base\App\Http\Controllers;
 
+use Enpii_Base\App\Models\Post;
 use Enpii_Base\App\WP\Enpii_Base_WP_Plugin;
 use Enpii_Base\Foundation\Http\Base_Controller;
 
 class Index_Controller extends Base_Controller {
 	public function index() {
 		// This will render the index.php template in the theme: wp_app_view( 'index' )
+
+		// Below would render the query like this
+		// "select * from `wps_posts` where
+		//	(`post_status` = ? or `post_title` LIKE ?)
+		//	or (`post_status` = ? and `post_title` LIKE ?)"
+		$queryBuilder = Post::where([
+			['post_status', '=', 'publish'],
+			['post_title', 'LIKE', "hello%", 'or'],
+		])
+		->orWhere([
+			['post_status', '=', 'draft'],
+			['post_title', 'LIKE', "%cy"],
+		]);
+		$post = $queryBuilder->firstOrFail();
+
 		return 'Welcome to WP App from Enpii Base';
 	}
 

--- a/src/App/Models/Post.php
+++ b/src/App/Models/Post.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enpii_Base\App\Models;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'posts';
+
+	/**
+	 * We may want to use Wpdb_Connection for the db
+	 * @var string
+	 */
+	protected $connection = 'wpdb';
+
+	public static function insert(...$params) {
+		// Use wp_insert_post() instead
+		throw new Exception('Invalid Method Call');
+	}
+
+	public function update(array $attributes = [], array $options = []) {
+		// Use wp_update_post() instead
+		throw new Exception('Invalid Method Call');
+	}
+
+	public function delete() {
+		// Use wp_delete_post() instead
+		throw new Exception('Invalid Method Call');
+	}
+}

--- a/src/App/Providers/Database_Service_Provider.php
+++ b/src/App/Providers/Database_Service_Provider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Enpii_Base\App\Providers;
 
 use Enpii_Base\Foundation\Database\Connectors\Connection_Factory;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\DatabaseServiceProvider;
+use Illuminate\Database\DatabaseTransactionsManager;
 
 class Database_Service_Provider extends DatabaseServiceProvider {
 	public function register() {
@@ -99,6 +101,7 @@ class Database_Service_Provider extends DatabaseServiceProvider {
 				'mysql_logs' => $default_mysql_config,
 				'mysql_queues' => $default_mysql_config,
 				'wpdb' => array_merge($default_mysql_config, [
+					'driver' => 'wpdb',
 					'wpdb' => $wpdb,
 				]),
 			],

--- a/src/App/Providers/Wpdb_Service_Provider.php
+++ b/src/App/Providers/Wpdb_Service_Provider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enpii_Base\App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class Wpdb_Service_Provider extends ServiceProvider {
+	/**
+     * Bootstrap the application events.
+     */
+    public function boot()
+    {
+        // Model::setConnectionResolver($this->app['db']);
+    }
+
+	public function register() {
+		$this->before_register();
+
+		// Add database driver.
+        $this->app->resolving('db', function ($db) {
+            $db->extend('wpdb', function ($config, $name) {
+                $config['name'] = $name;
+
+                return new Wpdb_Connection($config);
+            });
+        });
+	}
+
+	protected function before_register(): void {
+		wp_app_config(
+			[
+				'tinker' => apply_filters(
+					'enpii_base_wp_app_wpdb_config',
+					$this->get_default_config()
+				),
+			]
+		);
+	}
+
+	protected function get_default_config(): array {
+		$config = [
+
+		];
+
+		return $config;
+	}
+}

--- a/src/Foundation/Database/Connectors/Connection_Factory.php
+++ b/src/Foundation/Database/Connectors/Connection_Factory.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enpii_Base\Foundation\Database\Connectors;
+
+use Enpii_Base\Foundation\Database\Wpdb_Connection;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Connectors\ConnectionFactory;
+use InvalidArgumentException;
+
+class Connection_Factory extends ConnectionFactory {
+	/**
+     * Create a connector instance based on the configuration.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Database\Connectors\ConnectorInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function createConnector(array $config)
+    {
+        if (! isset($config['driver'])) {
+            throw new InvalidArgumentException('A driver must be specified.');
+        }
+
+        if ($this->container->bound($key = "db.connector.{$config['driver']}")) {
+            return $this->container->make($key);
+        }
+
+		if ($config['driver'] === 'wpdb') {
+			return new Wpdb_Connector;
+		}
+
+		return parent::createConnector($config);
+    }
+
+	/**
+     * Create a new connection instance.
+     *
+     * @param  string  $driver
+     * @param  \PDO|\Closure  $connection
+     * @param  string  $database
+     * @param  string  $prefix
+     * @param  array  $config
+     * @return \Illuminate\Database\Connection
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function createConnection($driver, $connection, $database, $prefix = '', array $config = [])
+    {
+		if ($resolver = Connection::getResolver($driver)) {
+            return $resolver($connection, $database, $prefix, $config);
+        }
+
+		if ($driver === 'wpdb') {
+			return new Wpdb_Connection($connection, $database, $prefix, $config);
+		}
+
+        return parent::createConnection($driver, $connection, $database, $prefix, $config);
+    }
+}

--- a/src/Foundation/Database/Connectors/Wpdb_Connector.php
+++ b/src/Foundation/Database/Connectors/Wpdb_Connector.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enpii_Base\Foundation\Database\Connectors;
+
+use Illuminate\Database\Connectors\MySqlConnector;
+
+class Wpdb_Connector extends MySqlConnector {
+}

--- a/src/Foundation/Database/Wpdb_Connection.php
+++ b/src/Foundation/Database/Wpdb_Connection.php
@@ -9,7 +9,6 @@ use Exception;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\UniqueConstraintViolationException;
-use Illuminate\Support\Arr;
 use PDO;
 
 class Wpdb_Connection extends MySqlConnection {
@@ -29,7 +28,7 @@ class Wpdb_Connection extends MySqlConnection {
     {
         parent::__construct($pdo, $database, $tablePrefix, $config);
 
-		$this->wpdb = $config['wpdb'];
+		$this->wpdb = !empty($config['wpdb']) ? $config['wpdb'] : $GLOBALS['wpdb'];
     }
 
 	/**
@@ -96,7 +95,7 @@ class Wpdb_Connection extends MySqlConnection {
 
 			$result = $this->wpdb->get_results($prepared_query);
 
-            return $result;
+			return $result;
         });
     }
 

--- a/src/Foundation/Database/Wpdb_Connection.php
+++ b/src/Foundation/Database/Wpdb_Connection.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enpii_Base\Foundation\Database;
+
+use Closure;
+use Exception;
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Arr;
+use PDO;
+
+class Wpdb_Connection extends MySqlConnection {
+	/** @var \wpdb $wpdb */
+	protected $wpdb;
+
+	/**
+     * Create a new database connection instance.
+     *
+     * @param  \PDO|\Closure  $pdo
+     * @param  string  $database
+     * @param  string  $tablePrefix
+     * @param  array  $config
+     * @return void
+     */
+    public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
+    {
+        parent::__construct($pdo, $database, $tablePrefix, $config);
+
+		$this->wpdb = $config['wpdb'];
+    }
+
+	/**
+     * Run a SQL statement.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  \Closure  $callback
+     * @return mixed
+     *
+     * @throws \Illuminate\Database\QueryException
+     */
+    protected function runQueryCallback($query, $bindings, Closure $callback)
+    {
+        // To execute the statement, we'll simply call the callback, which will actually
+        // run the SQL against the PDO connection. Then we can calculate the time it
+        // took to execute and log the query SQL, bindings and time in our memory.
+        try {
+			return $callback($query, $bindings);
+        }
+
+        // If an exception occurs when attempting to run a query, we'll format the error
+        // message to include the bindings with SQL, which will make this exception a
+        // lot more helpful to the developer instead of just the database's errors.
+        catch (Exception $e) {
+            if ($this->isUniqueConstraintError($e)) {
+                throw new UniqueConstraintViolationException(
+                    $this->getName(), $query, $this->prepareBindings($bindings), $e
+                );
+            }
+
+            throw new QueryException(
+                $this->getName(), $query, $this->prepareBindings($bindings), $e
+            );
+        }
+    }
+
+	/**
+     * Run a select statement against the database.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @return array
+     */
+    public function select($query, $bindings = [], $useReadPdo = true)
+    {
+		// TODO: we need to use the $wpdb to query queries later
+        return $this->run($query, $bindings, function ($query, $bindings) use ($useReadPdo) {
+			list($unbound_query, $to_be_bound, $new_bindings) = $this->convert_query_with_namespace($query, $bindings);
+			if (!empty($to_be_bound)) {
+				$prepared_query = $this->wpdb->prepare($unbound_query, $new_bindings);
+			} else {
+				$prepared_query = $query;
+			}
+
+
+			list($unbound_query, $to_be_bound, $new_bindings) = $this->convert_query_with_question_marks($query, $bindings);
+			if (!empty($to_be_bound)) {
+				$prepared_query = $this->wpdb->prepare($unbound_query, $new_bindings);
+			} else {
+				$prepared_query = $query;
+			}
+
+			$result = $this->wpdb->get_results($prepared_query);
+
+            return $result;
+        });
+    }
+
+	/**
+	 * Convert the PDO unbound (namespace) query to an unprepared wbdb query
+	 * e.g. select * from `wps_posts` where `wps_posts`.`id` = :id and status = :id
+	 * 		and abc = :name and xyz = :name and desc LIKE :desc limit 1
+	 * 	would be converted to
+	 * 		select * from `wps_posts` where `wps_posts`.`id` = %d and status = %d
+	 * 		and abc = %s and xyz = %s and desc LIKE %s limit 1
+	 * 	(with the proper to be bound values and binding values)
+	 *
+	 * @param mixed $query
+	 * @param array $bindings
+	 * @return array 3 items: new unprepared wbdb query, array of to be bound values
+	 * 					and binding values
+	 */
+	protected function convert_query_with_namespace($query, $bindings = []): array {
+		$new_bind_strings = [];
+		$new_bindings = [];
+		$new_query = $query;
+
+		$new_query = preg_replace_callback(
+			'/\:(\w+)/',
+			function (array $matches) use ($bindings, &$new_bind_strings, &$new_bindings) {
+				$binding_value = $bindings[$matches[1]];
+				$new_bind_strings[] = $this->determine_wbdb_bound_string($binding_value);
+				$new_bindings[] = $binding_value;
+				return $this->determine_wbdb_bound_string($binding_value);
+			},
+			$query
+		);
+
+		return [$new_query, $new_bind_strings, $new_bindings];
+	}
+
+	/**
+	 * Convert the PDO unbound (question marks) query to an unprepared wbdb query
+	 * e.g. select * from `wps_posts` where `wps_posts`.`id` = ? and status = ?
+	 * 		and desc LIKE ? limit 1
+	 * 	would be converted to
+	 * 		select * from `wps_posts` where `wps_posts`.`id` = %d and status = %d
+	 * 		and desc LIKE %s limit 1
+	 * 	(with the proper to be bound values and binding values)
+	 *
+	 * @param mixed $query
+	 * @param array $bindings
+	 * @return array 3 items: new unprepared wbdb query, array of to be bound values
+	 * 					and binding values
+	 */
+	protected function convert_query_with_question_marks($query, $bindings = []): array {
+		$new_bind_strings = [];
+		$new_bindings = [];
+		$new_query = $query;
+		if (is_array($bindings) && !empty($bindings)) {
+			foreach ($bindings as $tmp_index => $binding_value) {
+				if (is_int($tmp_index)) {
+					$tmp_index = (int) $tmp_index;
+					$new_bindings[$tmp_index] = $binding_value;
+					$new_bind_strings[$tmp_index] = $this->determine_wbdb_bound_string($binding_value);
+					$new_query = preg_replace('/\?/', (string) $new_bind_strings[$tmp_index], $new_query, 1);
+				}
+			}
+		}
+
+		return [$new_query, $new_bind_strings, $new_bindings];
+	}
+
+	/**
+	 * Produce the string to be used for wpdb to bind the values to wbdb query
+	 * @param mixed $value
+	 * @return string 	%d for integer
+	 * 					%f for float
+	 * 					%s for string
+	 * 					%i for identifiers
+	 */
+	protected function determine_wbdb_bound_string($value): string
+	{
+		if (is_int($value)) {
+			return '%d';
+		}
+
+		if (is_float($value)) {
+			return '%f';
+		}
+
+		if (is_string($value)) {
+			return '%s';
+		}
+
+		return '%i';
+	}
+}


### PR DESCRIPTION
- We may want to shift the execution of WP App to WordPress database handler wpdb, we can use the driver `wpdb` one.
- For this PR, only `select` query to be handled, the rest would be covered by PDO Mysql from Laravel