### PR TITLE
Bugfix - Telescope job watcher

### DIFF
--- a/dev-docs/02-development-logs.md
+++ b/dev-docs/02-development-logs.md
@@ -62,12 +62,5 @@ to perform the queue execution with the timeout set to 60 seconds.
 - We need to put migrations rules to a src folders then user the command `vendor:publish` (remember to assign the assets tags for migrations rules) to publish migrations to fake base path. If we use the command to create rules, new rules will be created with current date therefore it would affect the migration rule time and cause the confusion.
 - For Laravel 7, we need to specify the migration class name clearly, and we need to use CamelCase naming to match Laravel convention e.g. 'CreateActivityLogs' (not using `return new class extends Migration` like Laravel 8+)
 
-### Current Blockers
-
-Currently, we are able to make the queue work using
-```
-wp enpii-base artisan queue:work database --queue=high,default,low
-```
-but Telescope cannot watch the Jobs and we need to have the queue work on web access as well. Probaly, we may send an ajax request on each `wp-admin` web request to trigger the queue work.
-
-We try to trigger the queue work on webaccess
+### Blockers and solutions
+- We tried to use Job to put to Laravel queue but Telescope cannot record the Job. After several days, we found out that, on normal WP request, we didn't use the `$kernel->terminate()`, and Telescope used the event `terminating` of app() to send all entries to the DB, therefore, Telescope didn't log the entries for Jobs. We need to apply the `$kernel->terminate()` to the shutdown action.

--- a/src/App/Jobs/Process_WP_Api_Request_Job.php
+++ b/src/App/Jobs/Process_WP_Api_Request_Job.php
@@ -2,7 +2,6 @@
 
 namespace Enpii_Base\App\Jobs;
 
-use Enpii_Base\Foundation\Bus\Dispatchable_Trait;
 use Enpii_Base\Foundation\Shared\Base_Job;
 use Enpii_Base\Foundation\Support\Executable_Trait;
 
@@ -18,11 +17,12 @@ class Process_WP_Api_Request_Job extends Base_Job {
 		/** @var \Enpii_Base\App\Http\Kernel $kernel */
 		$kernel = wp_app()->make( \Illuminate\Contracts\Http\Kernel::class );
 
+		// We don't want to re-capture the request because we did that on WP_App_Bootstrap
 		/** @var \Enpii_Base\App\Http\Request $request */
-		$request = \Enpii_Base\App\Http\Request::capture();
+		$request = wp_app_request();
 		$response = $kernel->handle( $request );
-
 		$response->send();
+
 		$kernel->terminate( $request, $response );
 	}
 }

--- a/src/App/Jobs/WP_CLI/Show_Basic_Info_Job.php
+++ b/src/App/Jobs/WP_CLI/Show_Basic_Info_Job.php
@@ -18,7 +18,7 @@ class Show_Basic_Info_Job extends Base_Job {
 	 */
 	public function handle(): void {
 		/** @var array $wp_app_info */
-		$wp_app_info = Get_WP_App_Info::dispatchSync();
+		$wp_app_info = Get_WP_App_Info::execute_now();
 
 		foreach ( $wp_app_info as $info_key => $info_value ) {
 			WP_CLI::success( "Key $info_key: " . $info_value );

--- a/src/App/WP/WP_Application.php
+++ b/src/App/WP/WP_Application.php
@@ -83,7 +83,10 @@ class WP_Application extends Application {
 	 */
 	public function runningInConsole(): ?bool {
 		if ( $this->isRunningInConsole === null ) {
-			if ( strpos( wp_app_request()->getPathInfo(), 'wp-admin/admin/setup' ) !== false && wp_app_request()->get( 'force_app_running_in_console' ) ) {
+			if (
+				strpos( wp_app_request()->getPathInfo(), 'wp-admin/admin/setup' ) !== false && wp_app_request()->get( 'force_app_running_in_console' ) ||
+				strpos( wp_app_request()->getPathInfo(), 'queue-work' ) !== false && wp_app_request()->get( 'force_app_running_in_console' )
+			) {
 				$this->isRunningInConsole = true;
 			}
 		}


### PR DESCRIPTION
- Terminate wp_app() on WordPress shutdown action for Telescope to be able to store entries to database because Telescope does that on terminating event of wp_app()